### PR TITLE
Add carriage returns to the whitespace list

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -110,6 +110,7 @@ pub fn skip_whitespace<'input>(mut input: Input<'input>) -> Input<'input> {
         match c as char {
             ' ' => true,
             '\n' => true,
+            '\r' => true,
             _ => false,
         }
     }


### PR DESCRIPTION
Prevent windows files from causing "expected end of input"
